### PR TITLE
Use viewport width unit on #sideprojects padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ ul {padding:0 0 0 1.2em;list-style-type:square}
 dd {margin:0 0 1em 0}
 #intro {color:#fff;background-color:#151314;padding:81px}
 #intro a {color:white}
-#sideprojects {padding:81px 81px 131px 81px;margin:-50px 100px 0 81px;background-color:#E78EA4}
+#sideprojects {padding:81px 10vw 131px;margin:-50px 100px 0 81px;background-color:#E78EA4}
 #sideprojects a {color:white}
 #elsewhere {background-color:#00F4C4;margin:-50px 0 50px 0;padding:81px}
 #sideprojects a, #elsewhere a {color:black}


### PR DESCRIPTION
## Done

This change will make the padding of `#sideprojects` container relative to the width of the viewport to resolve content overspill on smaller screens.

This is done using the [Viewport width unit](https://www.sitepoint.com/css-viewport-units-quick-start/). A value of `10vw` is equal to 10% of the viewport width.

As you have a requirement for brevity, I was able to reduce the character length of this line of code by using the [CSS shorthand properties notation](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties). 

### How to ensure padding is never greater than 81px

**Note**: This change will, however, mean the left/right padding of your side projects container will continue to increase as the viewport increases in width. 

If you wish to ensure the left/right padding of `#sideprojects` never exceeds 81px, add an override via media query immediately after line 14, but you may wish to prioritise brevity. 

```css
@media (min-width:810px) {#sideprojects {padding:81px 81px 131px;}}
```